### PR TITLE
groonga-command-convert-format: add a new format option

### DIFF
--- a/groonga-command-parser.gemspec
+++ b/groonga-command-parser.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.licenses = ["LGPLv2.1+"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency("groonga-command", ">= 1.3.2")
+  spec.add_runtime_dependency("groonga-command", ">= 1.4.0")
   spec.add_runtime_dependency("json-stream")
 
   spec.add_development_dependency("test-unit")

--- a/lib/groonga/command/parser/command/groonga-command-convert-format.rb
+++ b/lib/groonga/command/parser/command/groonga-command-convert-format.rb
@@ -81,7 +81,7 @@ module Groonga
 
             option_parser.on("--elasticsearch-version=VERSION",
                              "Specify the Elasticsearch version",
-                             "Because the Elasticsearch's importformat" +
+                             "Because the Elasticsearch's import format" +
                                         " differs depending on version",
                              "Currently, we can specify 5, 6, 7, and 8" +
                                                       " in this option",

--- a/lib/groonga/command/parser/command/groonga-command-convert-format.rb
+++ b/lib/groonga/command/parser/command/groonga-command-convert-format.rb
@@ -81,6 +81,10 @@ module Groonga
 
             option_parser.on("--elasticsearch-version=VERSION",
                              "Specify the Elasticsearch version",
+                             "Because the Elasticsearch's importformat" +
+                                        " differs depending on version",
+                             "Currently, we can specify 5, 6, 7, and 8" +
+                                                      " in this option",
                              "Available only in elasticsearch format",
                              "[#{@elasticsearch_version}]") do |version|
               @elasticsearch_version = version

--- a/lib/groonga/command/parser/command/groonga-command-convert-format.rb
+++ b/lib/groonga/command/parser/command/groonga-command-convert-format.rb
@@ -77,6 +77,7 @@ module Groonga
                              "Available only in command format",
                              "[#{@pretty_print}]") do |boolean|
               @pretty_print = boolean
+            end
 
             option_parser.on("--elasticsearch-version=VERSION",
                              "Specify the Elasticsearch version",

--- a/lib/groonga/command/parser/command/groonga-command-convert-format.rb
+++ b/lib/groonga/command/parser/command/groonga-command-convert-format.rb
@@ -27,6 +27,7 @@ module Groonga
             @format = :command
             @uri_prefix = "http://localhost:10041"
             @pretty_print = true
+            @elasticsearch_version = 5
           end
 
           def run(argv=ARGV)
@@ -57,7 +58,7 @@ module Groonga
             option_parser.banner += " INPUT_PATH1 INPUT_PATH2 ..."
             option_parser.version = VERSION
 
-            formats = [:uri, :command]
+            formats = [:uri, :command, :elasticsearch]
             option_parser.on("--format=FORMAT", formats,
                              "Convert to FORMAT",
                              "Available formats #{formats.join(', ')}",
@@ -76,6 +77,12 @@ module Groonga
                              "Available only in command format",
                              "[#{@pretty_print}]") do |boolean|
               @pretty_print = boolean
+
+            option_parser.on("--elasticsearch-version=VERSION",
+                             "Specify the Elasticsearch version",
+                             "Available only in elasticsearch format",
+                             "[#{@elasticsearch_version}]") do |version|
+              @elasticsearch_version = version
             end
 
             option_parser.parse!(argv)
@@ -96,6 +103,8 @@ module Groonga
             case @format
             when :uri
               "#{@uri_prefix}#{command.to_uri_format}"
+            when :elasticsearch
+              command.to_elasticsearch_format(:version => @elasticsearch_version)
             else
               command.to_command_format(:pretty_print => @pretty_print)
             end


### PR DESCRIPTION
This option converts Groonga's dump format to Elasticsearch's import format.
This feature needs to groonga/groonga-command#10.

Usage:
```
groonga-command-convert-dump --format elasticserch groonga.dump.grn
or
groonga-command-convert-dump --format elasticserch --elasticsearch-version 7 groonga.dump.grn
```

We can specify 5, 6, 7, and 8 in elasticsearch-version.
Because the Elasticsearch's import format differs depending on version.
A default value of this option is 5.