### PR TITLE
Fix a bug that can't convert to the Elasticsearch format when a "load" command hasn't option name of "--value"

### DIFF
--- a/lib/groonga/command/parser/command/groonga-command-convert-format.rb
+++ b/lib/groonga/command/parser/command/groonga-command-convert-format.rb
@@ -106,7 +106,7 @@ module Groonga
                 loaded_values << header
               end
               parser.on_load_complete do |command|
-                command[:values] = loaded_values.to_s
+                command[:values] = JSON.generate(loaded_values)
                 puts(convert_format(command))
               end
             else

--- a/lib/groonga/command/parser/command/groonga-command-convert-format.rb
+++ b/lib/groonga/command/parser/command/groonga-command-convert-format.rb
@@ -86,6 +86,7 @@ module Groonga
                              "Currently, we can specify 5, 6, 7, and 8" +
                                                       " in this option",
                              "Available only in elasticsearch format",
+                             Integer,
                              "[#{@elasticsearch_version}]") do |version|
               @elasticsearch_version = version
             end

--- a/lib/groonga/command/parser/command/groonga-command-convert-format.rb
+++ b/lib/groonga/command/parser/command/groonga-command-convert-format.rb
@@ -102,8 +102,8 @@ module Groonga
               parser.on_load_value do |command, value|
                 loaded_values << value
               end
-              parser.on_load_columns do |command, header|
-                loaded_values << header
+              parser.on_load_columns do |command, columns|
+                command[:columns] ||= columns.join(",")
               end
               parser.on_load_complete do |command|
                 command[:values] = JSON.generate(loaded_values)

--- a/lib/groonga/command/parser/command/groonga-command-convert-format.rb
+++ b/lib/groonga/command/parser/command/groonga-command-convert-format.rb
@@ -95,8 +95,23 @@ module Groonga
 
           def convert(input)
             parser = Parser.new
-            parser.on_command do |command|
-              puts(convert_format(command))
+            case @format
+            when :elasticsearch
+              loaded_values = []
+              parser.on_load_value do |command, value|
+                loaded_values << value
+              end
+              parser.on_load_columns do |command, header|
+                loaded_values << header
+              end
+              parser.on_load_complete do |command|
+                command[:values] = loaded_values.to_s
+                puts(convert_format(command))
+              end
+            else
+              parser.on_command do |command|
+                puts(convert_format(command))
+              end
             end
             input.each_line do |line|
               parser << line


### PR DESCRIPTION
Currently, the following format of `load` command can't convert to the Elasticsearch format.

```
load --table Site
[
["_key","title"],
["http://example.org/","This is test record 1!"]
]
```
In addition, the type of a `--elasticsearch-version` option was unexpected.
We expect the Integer. However, the actual type is the String.

Therefore, we've fixed them.